### PR TITLE
not able to pull latest version from nexus

### DIFF
--- a/lib/shared/cookbooks/artifact/libraries/chef_artifact.rb
+++ b/lib/shared/cookbooks/artifact/libraries/chef_artifact.rb
@@ -101,18 +101,7 @@ class Chef
       # @return [String] the version number that latest resolves to or the passed in value
       def get_actual_version(node, artifact_location, ssl_verify=true)
         version = artifact_location.split(':')[2]
-        if latest?(version)
-          require 'nexus_cli'
-          require 'rexml/document'
-          config = data_bag_config_for(node, DATA_BAG_NEXUS)
-          if config.empty?
-            raise DataBagNotFound.new(DATA_BAG_NEXUS)
-          end
-          remote = NexusCli::RemoteFactory.create(config, ssl_verify)
-          REXML::Document.new(remote.get_artifact_info(artifact_location)).elements["//version"].text
-        else
-          version
-        end
+        version
       end
 
       # Downloads a file to disk from the configured Nexus server.


### PR DESCRIPTION
All circuits are calling artifact cookbook from oneops-admin. When user give version as latest, it tried to use nexus_cli, which we are not using to retrieve artifacts. Irrespective of version get_actual_version call fails. Fix: Fix includes returning version and latest rather than calling through nexus_cli. 